### PR TITLE
fix: start ent api should not do the ent generate during project generate.

### DIFF
--- a/api/gogen/gen.go
+++ b/api/gogen/gen.go
@@ -235,10 +235,10 @@ func DoGenProject(apiFile, dir, style string, g *GenContext) error {
 			return err
 		}
 
-		_, err = execx.Run("go run -mod=mod entgo.io/ent/cmd/ent generate ./ent/schema", dir)
-		if err != nil {
-			return err
-		}
+		// _, err = execx.Run("go run -mod=mod entgo.io/ent/cmd/ent generate ./ent/schema", dir)
+		// if err != nil {
+		// 	return err
+		// }
 
 		err = pathx.MkdirIfNotExist(filepath.Join(dir, "ent", "template"))
 		if err != nil {


### PR DESCRIPTION
No, `goctls api new -e Coin` will generate ent directory, and add a `Coin` schema in it.
But I think most times,  the model name may not the same with project name.
And, I may run the `make gen-ent`  many times in future.
So I think we can do the init generate delay.

About #40 