### PR TITLE
fix: can gen id only use uuid but no create_at

### DIFF
--- a/api/gogen/ent/api.tpl
+++ b/api/gogen/ent/api.tpl
@@ -3,7 +3,7 @@ import "../base.api"
 type (
     // The data of {{.modelNameSpace}} information | {{.modelName}}信息
     {{.modelName}}Info {
-        {{if .HasCreated}}Base{{if .useUUID}}UU{{end}}ID{{.IdType}}Info{{else}}Id        *{{.IdTypeLower}}    `json:"id,optional"`{{end}}{{.infoData}}
+        {{if .useUUID}}BaseUUIDInfo{{else if ne .IdType  ""}}BaseID{{.IdType}}Info{{else}}Id        *{{.IdTypeLower}}    `json:"id,optional"`{{end}}{{.infoData}}
     }
 
     // The response data of {{.modelNameSpace}} list | {{.modelName}}列表数据


### PR DESCRIPTION
Now we do not define the UUIDInfo and IDInfo, so simply use BaseUUIDInfo and BaseId{*}Info.
